### PR TITLE
SorrIssue328 Convert Type Hints gDoc to Markdown

### DIFF
--- a/docs/Python_Type_hints.md
+++ b/docs/Python_Type_hints.md
@@ -1,0 +1,270 @@
+<!--ts-->
+   * [# Why we use type hints](#-why-we-use-type-hints)
+   * [# What to annotate with type hints](#-what-to-annotate-with-type-hints)
+   * [# Conventions](#-conventions)
+      * [## Empty return](#-empty-return)
+      * [## Invoke tasks](#-invoke-tasks)
+      * [## Annotation for kwargs](#-annotation-for-kwargs)
+      * [## Any](#-any)
+      * [## np.array and np.ndarray](#-nparray-and-npndarray)
+   * [# Handling the annoying Incompatible types in assignment](#-handling-the-annoying-incompatible-types-in-assignment)
+   * [# Handling the annoying "None" has no attribute](#-handling-the-annoying-none-has-no-attribute)
+   * [# Disabling mypy errors](#-disabling-mypy-errors)
+   * [# What to do when you don't know what to do](#-what-to-do-when-you-dont-know-what-to-do)
+   * [# Library without types](#-library-without-types)
+   * [# Inferring types using unit tests](#-inferring-types-using-unit-tests)
+
+
+
+<!--te-->
+# \# Why we use type hints
+
+We use Python 3 type hints to:
+
+- Improve documentation
+- Allow mypy to perform static checking of the code, looking for bugs
+- Enforce the type checks at run-time, through automatic assertions (not
+  implemented yet)
+
+# \# What to annotate with type hints
+
+- We expect all new library code (i.e., that is not in a notebook) to have type
+  annotations
+- We annotate the function signature
+- We don't annotate the variables inside a function unless mypy reports that it
+  can't infer the type
+- We strive to get no errors / warnings from the linter, including mypy
+
+# \# Conventions
+
+## \#\# Empty return
+
+Return `-> None` if your function doesn't return
+
+- Pros:
+  - `mypy` checks functions only when there is at least an annotation: so using
+    `-> None` enables mypy to do type checking
+  - It reminds us that we need to use type hints
+- Cons:
+  - `None` is the default value and so it might seem redundant
+
+## \#\# Invoke tasks
+
+For some reason `invoke` does not like type hints, so we
+
+- Omit type hints for `invoke` tasks, i.e. functions with the `@task` decorator
+- Put `\# type: ignore` so that `mypy` does not complain Example:
+  `` \` @task def run_qa_tests( \# type: ignore ctx, stage="dev", version="", ):  ``\`
+
+## \#\# Annotation for `kwargs`
+
+- We use `kwargs: Any` and not `kwargs: Dict[str, Any]`
+- `\*` always binds to a `Tuple`, and `\*\*` always binds to a `Dict[str, Any]`.
+  Because of this restriction, type hints only need you to define the types of
+  the contained arguments. The type checker automatically adds the
+  `Tuple[_, ...]` and `Dict[str, _]` container types.
+- [[Reference article]{.underline}](https://adamj.eu/tech/2021/05/11/python-type-hints-args-and-kwargs/)
+
+## \#\# `Any`
+
+- `Any` type hint = no type hint
+- We try to avoid it everywhere when possible
+
+## \#\# `np.array` and `np.ndarray`
+
+- If you get something like the following lint:
+  `` \` dataflow/core/nodes/sklearn_models.py:537:[amp_mypy] error: Function "numpy.core.multiarray.array" is not valid as a type [valid-type]  ``\`
+  > Then the problem is probably that a parameter that the lint is related to
+  > has been types as `np.array` while it should be typed as `np.ndarray`:
+  >
+  > `x_vals: np.array` -> `x_vals: np.ndarray`
+
+# \# Handling the annoying `Incompatible types in assignment`
+
+- `mypy` assigns a single type to each variable for its entire scope
+- The problem is in common idioms where we use the same variable to store
+  different representations of the same data
+  > ``\`
+  >
+  > output : str = ...
+  >
+  > output = output.split("\\n")
+  >
+  > ...
+  >
+  > \# Process output.
+  >
+  > ...
+  >
+  > output = "\\n".join(output)
+  >
+  > ``\`
+- Unfortunately the proper solution is to use different variables
+  > ``\`
+  >
+  > output : str = ...
+  >
+  > output_as_array = output.split("\\n")
+  >
+  > ...
+  >
+  > \# Process output.
+  >
+  > ...
+  >
+  > output = "\\n".join(output_as_array)
+  >
+  > ``\`
+- Another case could be:
+  > ``\`
+  >
+  > from typing import Optional
+  >
+  > def test_func(arg: bool):
+  >
+  > ...
+  >
+  > var: Optional[bool] = ...
+  >
+  > dbg.dassert_is_not(var, None)
+  >
+  > test_func(arg=var)
+  >
+  > ``\`
+- Sometimes `mypy` doesn't pick up the `None` check, and warns that the function
+  expects a `bool` rather than an `Optional[bool]`. In that case, the solution
+  is to explicitly use `typing.cast` on the argument when passing it in, note
+  that `typing.cast` has no runtime effects and is purely for type checking.
+- Here're the relevant
+  [[docs]{.underline}](https://mypy.readthedocs.io/en/stable/casts.html)
+- So the solution would be:
+  > ``\`
+  >
+  > from typing import cast ...
+  >
+  > ...
+  >
+  > test_func(arg=cast(bool, var))
+  >
+  > ``\`
+
+# \# Handling the annoying `"None" has no attribute`
+
+- In some model classes `self._model` parameter is being assigned to `None` in
+  ctor and being set after calling `set_fit_state` method
+- The problem is that statically it's not possible to understand that someone
+  will call `set_fit_state` before using `self._model`, so when a model's method
+  is applied:
+  > ``\`
+  >
+  > self.\_model = self.\_model.fit(...)
+  >
+  > ``\`
+  >
+  > the following lint appears:
+  >
+  > ``\`
+  >
+  > dataflow/core/nodes/sklearn_models.py:155:[amp_mypy] error: "None" has no
+  > attribute "fit"
+  >
+  > ``\`
+- A solution is to
+  1. Type hint when assigning the model parameter in ctor:
+     `` \` self._model: Optional[sklearn.base.BaseEstimator] = None  ``\`
+     > 2. Cast a type to the model parameter after asserting that it is not
+     >    `None`:
+     >    `` \` hdbg.dassert_is_not(self._model, None) self._model = cast(sklearn.base.BaseEstimator, self._model)  ``\`
+
+# \# Disabling `mypy` errors
+
+- If `mypy` reports an error and you don't understand why, please ping one of
+  the python experts asking for help
+- If you are sure that you understand why `mypy` reports and error and that you
+  can override it, you disable this `error`
+- When you want to disable an error reported by `mypy`:
+  - Add a comment reporting the `mypy` error
+  - Explain why this is not a problem
+  - Add `\# type: ignore` with two spaces as usual for the inline comment
+  - Example
+    > ``\`
+    >
+    > \# mypy: Cannot find module named 'pyannotate_runtime'
+    >
+    > \# pyannotate is not always installed
+    >
+    > from pyannotate_runtime import collect_types \# type: ignore
+    >
+    > ``\`
+
+# \# What to do when you don't know what to do
+
+- Go to the
+  [[`mypy` official cheat sheet]{.underline}](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html)
+- Use `reveal_type`
+  - To find out what type `mypy` infers for an expression anywhere in your
+    program, wrap it in `reveal_type()`
+  - `mypy` will print an error message with the type; remove it again before
+    running the code
+  - See
+    [[the official `mypy` documentation]{.underline}](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html#when-you-re-puzzled-or-when-things-are-complicated)
+
+# \# Library without types
+
+- `mypy` is unhappy when a library doesn't have types
+- Lots of libraries are starting to add type hints now that python 2 has been
+  deprecated
+  > ``\`
+  >
+  > \*.py:14: error: No library stub file for module 'sklearn.model_selection'
+  > [mypy]
+  >
+  > ``\`
+- You can go in `mypy.ini` and add the library (following the alphabetical
+  order) to the list
+- Note that you need to ensure that different copies of `mypy.ini` in different
+  sub projects are equal
+  > ``\`
+  >
+  > > vimdiff mypy.ini amp/mypy.ini
+  >
+  > or
+  >
+  > > cp mypy.ini amp/mypy.ini
+  >
+  > ``\`
+
+# \# Inferring types using unit tests
+
+Sometimes it is possible to infer types directly from unit tests. We have used
+this flow to annotate the code when we switched to Python3 and it worked fine
+although there were various mistakes. We still prefer to annotate by hand based
+on what the code is intended to do, rather than automatically infer it from how
+the code behaves.
+
+- Install `pyannotate`
+  > ``\`
+  >
+  > > pip install pyannotate
+  >
+  > ``\`
+- To enable collecting type hints run
+  > ``\`
+  >
+  > > export PYANNOTATE=True
+  >
+  > ``\`
+- Run `pytest`, e.g., on a subset of unit tests:
+- Run `pytest`, e.g., on a subset of unit tests like `helpers`:
+  > ``\`
+  >
+  > > pytest helpers
+  >
+  > ``\`
+- A file `type_info.json` is generated
+- Annotate the code with the inferred types:
+  > ``\`
+  >
+  > > pyannotate -w --type-info type_info.json . --py3
+  >
+  > ``\`

--- a/docs/Python_Type_hints.md
+++ b/docs/Python_Type_hints.md
@@ -17,7 +17,7 @@
 
 
 <!--te-->
-# \# Why we use type hints
+# Why we use type hints
 
 We use Python 3 type hints to:
 
@@ -26,7 +26,7 @@ We use Python 3 type hints to:
 - Enforce the type checks at run-time, through automatic assertions (not
   implemented yet)
 
-# \# What to annotate with type hints
+# What to annotate with type hints
 
 - We expect all new library code (i.e., that is not in a notebook) to have type
   annotations
@@ -35,9 +35,9 @@ We use Python 3 type hints to:
   can't infer the type
 - We strive to get no errors / warnings from the linter, including mypy
 
-# \# Conventions
+# Conventions
 
-## \#\# Empty return
+## Empty return
 
 Return `-> None` if your function doesn't return
 
@@ -48,7 +48,7 @@ Return `-> None` if your function doesn't return
 - Cons:
   - `None` is the default value and so it might seem redundant
 
-## \#\# Invoke tasks
+## Invoke tasks
 
 For some reason `invoke` does not like type hints, so we
 
@@ -56,7 +56,7 @@ For some reason `invoke` does not like type hints, so we
 - Put `\# type: ignore` so that `mypy` does not complain Example:
   `` \` @task def run_qa_tests( \# type: ignore ctx, stage="dev", version="", ):  ``\`
 
-## \#\# Annotation for `kwargs`
+## Annotation for `kwargs`
 
 - We use `kwargs: Any` and not `kwargs: Dict[str, Any]`
 - `\*` always binds to a `Tuple`, and `\*\*` always binds to a `Dict[str, Any]`.
@@ -65,12 +65,12 @@ For some reason `invoke` does not like type hints, so we
   `Tuple[_, ...]` and `Dict[str, _]` container types.
 - [[Reference article]{.underline}](https://adamj.eu/tech/2021/05/11/python-type-hints-args-and-kwargs/)
 
-## \#\# `Any`
+## `Any`
 
 - `Any` type hint = no type hint
 - We try to avoid it everywhere when possible
 
-## \#\# `np.array` and `np.ndarray`
+## `np.array` and `np.ndarray`
 
 - If you get something like the following lint:
   `` \` dataflow/core/nodes/sklearn_models.py:537:[amp_mypy] error: Function "numpy.core.multiarray.array" is not valid as a type [valid-type]  ``\`
@@ -79,7 +79,7 @@ For some reason `invoke` does not like type hints, so we
   >
   > `x_vals: np.array` -> `x_vals: np.ndarray`
 
-# \# Handling the annoying `Incompatible types in assignment`
+# Handling the annoying `Incompatible types in assignment`
 
 - `mypy` assigns a single type to each variable for its entire scope
 - The problem is in common idioms where we use the same variable to store
@@ -148,7 +148,7 @@ For some reason `invoke` does not like type hints, so we
   >
   > ``\`
 
-# \# Handling the annoying `"None" has no attribute`
+# Handling the annoying `"None" has no attribute`
 
 - In some model classes `self._model` parameter is being assigned to `None` in
   ctor and being set after calling `set_fit_state` method
@@ -176,7 +176,7 @@ For some reason `invoke` does not like type hints, so we
      >    `None`:
      >    `` \` hdbg.dassert_is_not(self._model, None) self._model = cast(sklearn.base.BaseEstimator, self._model)  ``\`
 
-# \# Disabling `mypy` errors
+# Disabling `mypy` errors
 
 - If `mypy` reports an error and you don't understand why, please ping one of
   the python experts asking for help
@@ -197,7 +197,7 @@ For some reason `invoke` does not like type hints, so we
     >
     > ``\`
 
-# \# What to do when you don't know what to do
+# What to do when you don't know what to do
 
 - Go to the
   [[`mypy` official cheat sheet]{.underline}](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html)
@@ -209,7 +209,7 @@ For some reason `invoke` does not like type hints, so we
   - See
     [[the official `mypy` documentation]{.underline}](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html#when-you-re-puzzled-or-when-things-are-complicated)
 
-# \# Library without types
+# Library without types
 
 - `mypy` is unhappy when a library doesn't have types
 - Lots of libraries are starting to add type hints now that python 2 has been
@@ -234,7 +234,7 @@ For some reason `invoke` does not like type hints, so we
   >
   > ``\`
 
-# \# Inferring types using unit tests
+# Inferring types using unit tests
 
 Sometimes it is possible to infer types directly from unit tests. We have used
 this flow to annotate the code when we switched to Python3 and it worked fine

--- a/docs/Python_Type_hints.md
+++ b/docs/Python_Type_hints.md
@@ -1,22 +1,22 @@
+# Python - Type hints
+
 <!--ts-->
-   * [# Why we use type hints](#-why-we-use-type-hints)
-   * [# What to annotate with type hints](#-what-to-annotate-with-type-hints)
-   * [# Conventions](#-conventions)
-      * [## Empty return](#-empty-return)
-      * [## Invoke tasks](#-invoke-tasks)
-      * [## Annotation for kwargs](#-annotation-for-kwargs)
-      * [## Any](#-any)
-      * [## np.array and np.ndarray](#-nparray-and-npndarray)
-   * [# Handling the annoying Incompatible types in assignment](#-handling-the-annoying-incompatible-types-in-assignment)
-   * [# Handling the annoying "None" has no attribute](#-handling-the-annoying-none-has-no-attribute)
-   * [# Disabling mypy errors](#-disabling-mypy-errors)
-   * [# What to do when you don't know what to do](#-what-to-do-when-you-dont-know-what-to-do)
-   * [# Library without types](#-library-without-types)
-   * [# Inferring types using unit tests](#-inferring-types-using-unit-tests)
-
-
-
+   * [Why we use type hints](#-why-we-use-type-hints)
+   * [What to annotate with type hints](#-what-to-annotate-with-type-hints)
+   * [Conventions](#-conventions)
+      * [Empty return](#-empty-return)
+      * [Invoke tasks](#-invoke-tasks)
+      * [Annotation for kwargs](#-annotation-for-kwargs)
+      * [Any](#-any)
+      * [np.array and np.ndarray](#-nparray-and-npndarray)
+   * [Handling the annoying Incompatible types in assignment](#-handling-the-annoying-incompatible-types-in-assignment)
+   * [Handling the annoying "None" has no attribute](#-handling-the-annoying-none-has-no-attribute)
+   * [Disabling mypy errors](#-disabling-mypy-errors)
+   * [What to do when you don't know what to do](#-what-to-do-when-you-dont-know-what-to-do)
+   * [Library without types](#-library-without-types)
+   * [Inferring types using unit tests](#-inferring-types-using-unit-tests)
 <!--te-->
+
 # Why we use type hints
 
 We use Python 3 type hints to:
@@ -53,18 +53,25 @@ Return `-> None` if your function doesn't return
 For some reason `invoke` does not like type hints, so we
 
 - Omit type hints for `invoke` tasks, i.e. functions with the `@task` decorator
-- Put `\# type: ignore` so that `mypy` does not complain Example:
-  `` \` @task def run_qa_tests( \# type: ignore ctx, stage="dev", version="", ):  ``\`
+- Put `# type: ignore` so that `mypy` does not complain
+
+Example:
+  ```python
+  @task def run_qa_tests( # type: ignore 
+    ctx, 
+    stage="dev", 
+    version="", 
+  ):  
+  ```
 
 ## Annotation for `kwargs`
 
 - We use `kwargs: Any` and not `kwargs: Dict[str, Any]`
-- `\*` always binds to a `Tuple`, and `\*\*` always binds to a `Dict[str, Any]`.
+- `*` always binds to a `Tuple`, and `**` always binds to a `Dict[str, Any]`.
   Because of this restriction, type hints only need you to define the types of
   the contained arguments. The type checker automatically adds the
   `Tuple[_, ...]` and `Dict[str, _]` container types.
-- [[Reference article]{.underline}](https://adamj.eu/tech/2021/05/11/python-type-hints-args-and-kwargs/)
-
+- [Reference article](https://adamj.eu/tech/2021/05/11/python-type-hints-args-and-kwargs/)
 ## `Any`
 
 - `Any` type hint = no type hint
@@ -73,80 +80,57 @@ For some reason `invoke` does not like type hints, so we
 ## `np.array` and `np.ndarray`
 
 - If you get something like the following lint:
-  `` \` dataflow/core/nodes/sklearn_models.py:537:[amp_mypy] error: Function "numpy.core.multiarray.array" is not valid as a type [valid-type]  ``\`
-  > Then the problem is probably that a parameter that the lint is related to
-  > has been types as `np.array` while it should be typed as `np.ndarray`:
-  >
-  > `x_vals: np.array` -> `x_vals: np.ndarray`
+  ```bash
+  dataflow/core/nodes/sklearn_models.py:537:[amp_mypy] error: Function "numpy.core.multiarray.array" is not valid as a type [valid-type]  
+  ```
+  Then the problem is probably that a parameter that the lint is related to
+  has been types as `np.array` while it should be typed as `np.ndarray`:
+  ```bash
+  `x_vals: np.array` -> `x_vals: np.ndarray`
+  ```
 
 # Handling the annoying `Incompatible types in assignment`
 
 - `mypy` assigns a single type to each variable for its entire scope
 - The problem is in common idioms where we use the same variable to store
   different representations of the same data
-  > ``\`
-  >
-  > output : str = ...
-  >
-  > output = output.split("\\n")
-  >
-  > ...
-  >
-  > \# Process output.
-  >
-  > ...
-  >
-  > output = "\\n".join(output)
-  >
-  > ``\`
+  ```bash
+  output : str = ...
+  output = output.split("\n")
+  ...
+  # Process output.
+  ...
+  output = "\n".join(output)
+  ```
 - Unfortunately the proper solution is to use different variables
-  > ``\`
-  >
-  > output : str = ...
-  >
-  > output_as_array = output.split("\\n")
-  >
-  > ...
-  >
-  > \# Process output.
-  >
-  > ...
-  >
-  > output = "\\n".join(output_as_array)
-  >
-  > ``\`
+  ```bash
+  output : str = ...
+  output_as_array = output.split("\n")
+  ...
+  # Process output.
+  ...
+  output = "\n".join(output_as_array)
+  ```
 - Another case could be:
-  > ``\`
-  >
-  > from typing import Optional
-  >
-  > def test_func(arg: bool):
-  >
-  > ...
-  >
-  > var: Optional[bool] = ...
-  >
-  > dbg.dassert_is_not(var, None)
-  >
-  > test_func(arg=var)
-  >
-  > ``\`
+  ```bash
+  from typing import Optional
+  def test_func(arg: bool):
+  ...
+  var: Optional[bool] = ...
+  dbg.dassert_is_not(var, None)
+  test_func(arg=var)
+  ```
 - Sometimes `mypy` doesn't pick up the `None` check, and warns that the function
   expects a `bool` rather than an `Optional[bool]`. In that case, the solution
   is to explicitly use `typing.cast` on the argument when passing it in, note
   that `typing.cast` has no runtime effects and is purely for type checking.
-- Here're the relevant
-  [[docs]{.underline}](https://mypy.readthedocs.io/en/stable/casts.html)
+- Here're the relevant [docs](https://mypy.readthedocs.io/en/stable/casts.html)
 - So the solution would be:
-  > ``\`
-  >
-  > from typing import cast ...
-  >
-  > ...
-  >
-  > test_func(arg=cast(bool, var))
-  >
-  > ``\`
+  ```bash
+  from typing import cast ...
+  ...
+  test_func(arg=cast(bool, var))
+  ```
 
 # Handling the annoying `"None" has no attribute`
 
@@ -155,26 +139,22 @@ For some reason `invoke` does not like type hints, so we
 - The problem is that statically it's not possible to understand that someone
   will call `set_fit_state` before using `self._model`, so when a model's method
   is applied:
-  > ``\`
-  >
-  > self.\_model = self.\_model.fit(...)
-  >
-  > ``\`
-  >
-  > the following lint appears:
-  >
-  > ``\`
-  >
-  > dataflow/core/nodes/sklearn_models.py:155:[amp_mypy] error: "None" has no
-  > attribute "fit"
-  >
-  > ``\`
+  ```bash
+  self._model = self._model.fit(...)
+  ```
+  the following lint appears:
+  ```bash
+  dataflow/core/nodes/sklearn_models.py:155:[amp_mypy] error: "None" has no attribute "fit"
+  ```
 - A solution is to
   1. Type hint when assigning the model parameter in ctor:
-     `` \` self._model: Optional[sklearn.base.BaseEstimator] = None  ``\`
-     > 2. Cast a type to the model parameter after asserting that it is not
-     >    `None`:
-     >    `` \` hdbg.dassert_is_not(self._model, None) self._model = cast(sklearn.base.BaseEstimator, self._model)  ``\`
+     ```bash
+     self._model: Optional[sklearn.base.BaseEstimator] = None
+     ```
+  2. Cast a type to the model parameter after asserting that it is not `None`:
+     ```bash
+     hdbg.dassert_is_not(self._model, None) self._model = cast(sklearn.base.BaseEstimator, self._model)
+     ```
 
 # Disabling `mypy` errors
 
@@ -185,54 +165,41 @@ For some reason `invoke` does not like type hints, so we
 - When you want to disable an error reported by `mypy`:
   - Add a comment reporting the `mypy` error
   - Explain why this is not a problem
-  - Add `\# type: ignore` with two spaces as usual for the inline comment
+  - Add `# type: ignore` with two spaces as usual for the inline comment
   - Example
-    > ``\`
-    >
-    > \# mypy: Cannot find module named 'pyannotate_runtime'
-    >
-    > \# pyannotate is not always installed
-    >
-    > from pyannotate_runtime import collect_types \# type: ignore
-    >
-    > ``\`
+    ```bash
+    # mypy: Cannot find module named 'pyannotate_runtime'
+    # pyannotate is not always installed
+    from pyannotate_runtime import collect_types # type: ignore
+    ```
 
 # What to do when you don't know what to do
 
-- Go to the
-  [[`mypy` official cheat sheet]{.underline}](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html)
+- Go to the [`mypy` official cheat sheet](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html)
 - Use `reveal_type`
   - To find out what type `mypy` infers for an expression anywhere in your
     program, wrap it in `reveal_type()`
   - `mypy` will print an error message with the type; remove it again before
     running the code
-  - See
-    [[the official `mypy` documentation]{.underline}](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html#when-you-re-puzzled-or-when-things-are-complicated)
+  - See [the official `mypy` documentation](https://mypy.readthedocs.io/en/stable/cheat_sheet_py3.html#when-you-re-puzzled-or-when-things-are-complicated)
 
 # Library without types
 
 - `mypy` is unhappy when a library doesn't have types
 - Lots of libraries are starting to add type hints now that python 2 has been
   deprecated
-  > ``\`
-  >
-  > \*.py:14: error: No library stub file for module 'sklearn.model_selection'
-  > [mypy]
-  >
-  > ``\`
+  ```bash
+  *.py:14: error: No library stub file for module 'sklearn.model_selection' [mypy]
+  ```
 - You can go in `mypy.ini` and add the library (following the alphabetical
   order) to the list
 - Note that you need to ensure that different copies of `mypy.ini` in different
   sub projects are equal
-  > ``\`
-  >
-  > > vimdiff mypy.ini amp/mypy.ini
-  >
-  > or
-  >
-  > > cp mypy.ini amp/mypy.ini
-  >
-  > ``\`
+  ```bash
+  > vimdiff mypy.ini amp/mypy.ini
+  or
+  > cp mypy.ini amp/mypy.ini
+  ```
 
 # Inferring types using unit tests
 
@@ -243,28 +210,20 @@ on what the code is intended to do, rather than automatically infer it from how
 the code behaves.
 
 - Install `pyannotate`
-  > ``\`
-  >
-  > > pip install pyannotate
-  >
-  > ``\`
+  ```bash
+  > pip install pyannotate
+  ```
 - To enable collecting type hints run
-  > ``\`
-  >
-  > > export PYANNOTATE=True
-  >
-  > ``\`
+  ```bash
+  > export PYANNOTATE=True
+  ```
 - Run `pytest`, e.g., on a subset of unit tests:
 - Run `pytest`, e.g., on a subset of unit tests like `helpers`:
-  > ``\`
-  >
-  > > pytest helpers
-  >
-  > ``\`
+  ```bash
+  > pytest helpers
+  ```
 - A file `type_info.json` is generated
 - Annotate the code with the inferred types:
-  > ``\`
-  >
-  > > pyannotate -w --type-info type_info.json . --py3
-  >
-  > ``\`
+  ```bash
+  > pyannotate -w --type-info type_info.json . --py3
+  ```

--- a/docs/Python_Type_hints.md
+++ b/docs/Python_Type_hints.md
@@ -1,21 +1,23 @@
 # Python - Type hints
 
-<!--ts-->
-   * [Why we use type hints](#-why-we-use-type-hints)
-   * [What to annotate with type hints](#-what-to-annotate-with-type-hints)
-   * [Conventions](#-conventions)
-      * [Empty return](#-empty-return)
-      * [Invoke tasks](#-invoke-tasks)
-      * [Annotation for kwargs](#-annotation-for-kwargs)
-      * [Any](#-any)
-      * [np.array and np.ndarray](#-nparray-and-npndarray)
-   * [Handling the annoying Incompatible types in assignment](#-handling-the-annoying-incompatible-types-in-assignment)
-   * [Handling the annoying "None" has no attribute](#-handling-the-annoying-none-has-no-attribute)
-   * [Disabling mypy errors](#-disabling-mypy-errors)
-   * [What to do when you don't know what to do](#-what-to-do-when-you-dont-know-what-to-do)
-   * [Library without types](#-library-without-types)
-   * [Inferring types using unit tests](#-inferring-types-using-unit-tests)
-<!--te-->
+<!-- toc -->
+
+   - [Why we use type hints](#why-we-use-type-hints)
+   - [What to annotate with type hints](#what-to-annotate-with-type-hints)
+   - [Conventions](#conventions)
+      * [Empty return](#empty-return)
+      * [Invoke tasks](#invoke-tasks)
+      * [Annotation for kwargs](#annotation-for-kwargs)
+      * [Any](#any)
+      * [np.array and np.ndarray](#nparray-and-npndarray)
+   - [Handling the annoying Incompatible types in assignment](#handling-the-annoying-incompatible-types-in-assignment)
+   - [Handling the annoying "None" has no attribute](#handling-the-annoying-none-has-no-attribute)
+   - [Disabling mypy errors](#disabling-mypy-errors)
+   - [What to do when you don't know what to do](#what-to-do-when-you-dont-know-what-to-do)
+   - [Library without types](#library-without-types)
+   - [Inferring types using unit tests](#inferring-types-using-unit-tests)
+
+<!-- tocstop -->
 
 # Why we use type hints
 
@@ -72,6 +74,7 @@ Example:
   the contained arguments. The type checker automatically adds the
   `Tuple[_, ...]` and `Dict[str, _]` container types.
 - [Reference article](https://adamj.eu/tech/2021/05/11/python-type-hints-args-and-kwargs/)
+
 ## `Any`
 
 - `Any` type hint = no type hint

--- a/docs/Python_Type_hints.md
+++ b/docs/Python_Type_hints.md
@@ -58,7 +58,8 @@
 
 - Example:
   ```python
-  @task def run_qa_tests( # type: ignore 
+  @task 
+  def run_qa_tests( # type: ignore 
     ctx, 
     stage="dev", 
     version="", 
@@ -86,8 +87,8 @@
   dataflow/core/nodes/sklearn_models.py:537:[amp_mypy] error: Function "numpy.core.multiarray.array" is not valid as a type [valid-type]  
   ```
 - Then the problem is probably that a parameter that the lint is related to
-  has been types as `np.array` while it should be typed as `np.ndarray`:
-  ```bash
+  has been typed as `np.array` while it should be typed as `np.ndarray`:
+  ```python
   `x_vals: np.array` -> `x_vals: np.ndarray`
   ```
 
@@ -96,7 +97,7 @@
 - `mypy` assigns a single type to each variable for its entire scope
 - The problem is in common idioms where we use the same variable to store
   different representations of the same data
-  ```bash
+  ```python
   output : str = ...
   output = output.split("\n")
   ...
@@ -105,7 +106,7 @@
   output = "\n".join(output)
   ```
 - Unfortunately the proper solution is to use different variables
-  ```bash
+  ```python
   output : str = ...
   output_as_array = output.split("\n")
   ...
@@ -114,7 +115,7 @@
   output = "\n".join(output_as_array)
   ```
 - Another case could be:
-  ```bash
+  ```python
   from typing import Optional
   def test_func(arg: bool):
   ...
@@ -128,7 +129,7 @@
   that `typing.cast` has no runtime effects and is purely for type checking.
 - Here're the relevant [docs](https://mypy.readthedocs.io/en/stable/casts.html)
 - So the solution would be:
-  ```bash
+  ```python
   from typing import cast ...
   ...
   test_func(arg=cast(bool, var))
@@ -141,7 +142,7 @@
 - The problem is that statically it's not possible to understand that someone
   will call `set_fit_state` before using `self._model`, so when a model's method
   is applied:
-  ```bash
+  ```python
   self._model = self._model.fit(...)
   ```
   the following lint appears:
@@ -149,13 +150,14 @@
   dataflow/core/nodes/sklearn_models.py:155:[amp_mypy] error: "None" has no attribute "fit"
   ```
 - A solution is to
-  - 1. Type hint when assigning the model parameter in ctor:
-     ```bash
+  - Type hint when assigning the model parameter in ctor:
+     ```python
      self._model: Optional[sklearn.base.BaseEstimator] = None
      ```
-  - 2. Cast a type to the model parameter after asserting that it is not `None`:
-     ```bash
-     hdbg.dassert_is_not(self._model, None) self._model = cast(sklearn.base.BaseEstimator, self._model)
+  - Cast a type to the model parameter after asserting that it is not `None`:
+     ```python
+     hdbg.dassert_is_not(self._model, None)
+     self._model = cast(sklearn.base.BaseEstimator, self._model)
      ```
 
 # Disabling `mypy` errors
@@ -169,7 +171,7 @@
   - Explain why this is not a problem
   - Add `# type: ignore` with two spaces as usual for the inline comment
   - Example
-    ```bash
+    ```python
     # mypy: Cannot find module named 'pyannotate_runtime'
     # pyannotate is not always installed
     from pyannotate_runtime import collect_types # type: ignore

--- a/docs/Python_Type_hints.md
+++ b/docs/Python_Type_hints.md
@@ -21,12 +21,11 @@
 
 # Why we use type hints
 
-We use Python 3 type hints to:
+- We use Python 3 type hints to:
 
-- Improve documentation
-- Allow mypy to perform static checking of the code, looking for bugs
-- Enforce the type checks at run-time, through automatic assertions (not
-  implemented yet)
+  - Improve documentation
+  - Allow mypy to perform static checking of the code, looking for bugs
+  - Enforce the type checks at run-time, through automatic assertions (not implemented yet)
 
 # What to annotate with type hints
 
@@ -41,23 +40,23 @@ We use Python 3 type hints to:
 
 ## Empty return
 
-Return `-> None` if your function doesn't return
+- Return `-> None` if your function doesn't return
 
-- Pros:
-  - `mypy` checks functions only when there is at least an annotation: so using
-    `-> None` enables mypy to do type checking
-  - It reminds us that we need to use type hints
-- Cons:
-  - `None` is the default value and so it might seem redundant
+  - Pros:
+    - `mypy` checks functions only when there is at least an annotation: so using
+      `-> None` enables mypy to do type checking
+    - It reminds us that we need to use type hints
+  - Cons:
+    - `None` is the default value and so it might seem redundant
 
 ## Invoke tasks
 
-For some reason `invoke` does not like type hints, so we
+- For some reason `invoke` does not like type hints, so we
 
-- Omit type hints for `invoke` tasks, i.e. functions with the `@task` decorator
-- Put `# type: ignore` so that `mypy` does not complain
+  - Omit type hints for `invoke` tasks, i.e. functions with the `@task` decorator
+  - Put `# type: ignore` so that `mypy` does not complain
 
-Example:
+- Example:
   ```python
   @task def run_qa_tests( # type: ignore 
     ctx, 
@@ -86,7 +85,7 @@ Example:
   ```bash
   dataflow/core/nodes/sklearn_models.py:537:[amp_mypy] error: Function "numpy.core.multiarray.array" is not valid as a type [valid-type]  
   ```
-  Then the problem is probably that a parameter that the lint is related to
+- Then the problem is probably that a parameter that the lint is related to
   has been types as `np.array` while it should be typed as `np.ndarray`:
   ```bash
   `x_vals: np.array` -> `x_vals: np.ndarray`
@@ -150,11 +149,11 @@ Example:
   dataflow/core/nodes/sklearn_models.py:155:[amp_mypy] error: "None" has no attribute "fit"
   ```
 - A solution is to
-  1. Type hint when assigning the model parameter in ctor:
+  - 1. Type hint when assigning the model parameter in ctor:
      ```bash
      self._model: Optional[sklearn.base.BaseEstimator] = None
      ```
-  2. Cast a type to the model parameter after asserting that it is not `None`:
+  - 2. Cast a type to the model parameter after asserting that it is not `None`:
      ```bash
      hdbg.dassert_is_not(self._model, None) self._model = cast(sklearn.base.BaseEstimator, self._model)
      ```
@@ -206,27 +205,27 @@ Example:
 
 # Inferring types using unit tests
 
-Sometimes it is possible to infer types directly from unit tests. We have used
+- Sometimes it is possible to infer types directly from unit tests. We have used
 this flow to annotate the code when we switched to Python3 and it worked fine
 although there were various mistakes. We still prefer to annotate by hand based
 on what the code is intended to do, rather than automatically infer it from how
 the code behaves.
 
-- Install `pyannotate`
-  ```bash
-  > pip install pyannotate
-  ```
-- To enable collecting type hints run
-  ```bash
-  > export PYANNOTATE=True
-  ```
-- Run `pytest`, e.g., on a subset of unit tests:
-- Run `pytest`, e.g., on a subset of unit tests like `helpers`:
-  ```bash
-  > pytest helpers
-  ```
-- A file `type_info.json` is generated
-- Annotate the code with the inferred types:
-  ```bash
-  > pyannotate -w --type-info type_info.json . --py3
-  ```
+  - Install `pyannotate`
+    ```bash
+    > pip install pyannotate
+    ```
+  - To enable collecting type hints run
+    ```bash
+    > export PYANNOTATE=True
+    ```
+  - Run `pytest`, e.g., on a subset of unit tests:
+  - Run `pytest`, e.g., on a subset of unit tests like `helpers`:
+    ```bash
+    > pytest helpers
+    ```
+  - A file `type_info.json` is generated
+  - Annotate the code with the inferred types:
+    ```bash
+    > pyannotate -w --type-info type_info.json . --py3
+    ```

--- a/docs/Type_hints.md
+++ b/docs/Type_hints.md
@@ -1,4 +1,4 @@
-# Python - Type hints
+# Type hints
 
 <!-- toc -->
 


### PR DESCRIPTION
Instructions told me that "The entire conversion flow is in dev_scripts/convert_gdoc_to_markdown.sh", but I can't find it, now I know it called ./dev_scripts/convert_docx_to_markdown.sh.

I redo it and here is update