### PR TITLE
CmampTask5211_gh_auth_login_does_not_work_when_running_via_sorrentum_github_actions_2

### DIFF
--- a/helpers/test/test_lib_tasks.py
+++ b/helpers/test/test_lib_tasks.py
@@ -133,7 +133,9 @@ def _gh_login() -> None:
 
 # TODO(ShaopengZ): fails when running Sorrentum on ck server. `gh auth login`
 # issue.
-@pytest.mark.skip
+# the CmampTask5211 branch on Sorrentum: to reproduce the gh auth login error
+# on gh workflow. 
+# @pytest.mark.skip
 class TestGhLogin1(hunitest.TestCase):
     def test_gh_login(self) -> None:
         _gh_login()


### PR DESCRIPTION
Trying to reproduce the `gh auth login` error on sorrentum under gh action, as mentioned in #566 and in CmampTask5211.