### PR TITLE
Bugfix for empty model

### DIFF
--- a/helpers/hchatgpt.py
+++ b/helpers/hchatgpt.py
@@ -70,6 +70,8 @@ def create_assistant(
         tools.append({"type": "code_interpreter"})
     if use_function:
         tools.append(use_function)
+    if not model:
+        model = "gpt-3.5-turbo-1106"
     assistant = client.beta.assistants.create(
         instructions=instructions,
         name=assistant_name,


### PR DESCRIPTION
#631 
@gpsaggese a quick fix as mentioned in tg.
Fixed a bug where code will crash if no model is given. Now default model is correctly set as `gpt-3.5-turbo-1106`